### PR TITLE
Importing math

### DIFF
--- a/plotlybrain/choropleth_render.py
+++ b/plotlybrain/choropleth_render.py
@@ -5,6 +5,7 @@ Choropleth rendering of Allen atlas slice GeoJSONs with Plotly.
 
 from __future__ import annotations
 import pandas as pd
+import math
 import plotly.express as px
 import plotly.graph_objects as go
 from plotly.colors import sample_colorscale


### PR DESCRIPTION
This PR is very simple and addresses issue #30 

The problem is that, when moving the function ``value_to_color`` from the old implementation on ``plotly_render.py`` to ``choropleth_render.py`` I forgot to add the ``import math``, so the export of either current or all slices, was not working. 

But now it does, this was tested locally. 